### PR TITLE
Rename TimeZoneType Find methods

### DIFF
--- a/src/main/java/org/example/time/timezone/TimeZoneType.java
+++ b/src/main/java/org/example/time/timezone/TimeZoneType.java
@@ -66,14 +66,14 @@ public enum TimeZoneType {
         return timeZoneStr;
     }
 
-    public static String Find(TimeZoneType eTimeZone) {
+    public static String find(TimeZoneType eTimeZone) {
         final String result = timeZone.get(eTimeZone);
         if (result != null) return result;
 
         throw new IllegalArgumentException();
     }
 
-    public static TimeZoneType Find(String timeZoneStr) {
+    public static TimeZoneType find(String timeZoneStr) {
         final TimeZoneType result = timeZoneId.get(timeZoneStr);
         if (result != null) return result;
 

--- a/src/main/java/org/example/time/timezone/Timezone.java
+++ b/src/main/java/org/example/time/timezone/Timezone.java
@@ -14,12 +14,12 @@ public class Timezone {
     }
 
     public Timezone(final String desireTimeZone) {
-        this(TimeZoneType.Find(desireTimeZone));
+        this(TimeZoneType.find(desireTimeZone));
     }
 
 
     public Timezone(final TimeZoneType desireTimeZone) {
-        this(ZoneId.of(desireTimeZone.getTimeZoneStr()), TimeZoneType.Find(desireTimeZone));
+        this(ZoneId.of(desireTimeZone.getTimeZoneStr()), TimeZoneType.find(desireTimeZone));
     }
 
     private Timezone(ZoneId timeZoneId, String timeZoneStr) {


### PR DESCRIPTION
## Summary
- rename `Find` methods in `TimeZoneType` to `find`
- use new `find` methods from `Timezone`

## Testing
- `./gradlew test` *(fails: No route to host)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
	- Updated method names for time zone lookups to use a consistent lowercase format in the user-facing API. No changes to functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->