### PR TITLE
Switch coroutine to use Consumer and add pacing control

### DIFF
--- a/src/main/java/org/example/time/timecal/TimeStringCal.java
+++ b/src/main/java/org/example/time/timecal/TimeStringCal.java
@@ -10,7 +10,7 @@ import static org.example.time.timeformat.TimeFormStd.YYYYMMDDHH24MISSNANO;
 
 import java.time.LocalDateTime;
 import java.time.temporal.ChronoUnit;
-import org.example.delegate.Action1;
+import java.util.function.Consumer;
 import org.example.time.timeformat.ITimeForm;
 import org.example.time.timeformat.TimeForm;
 
@@ -84,7 +84,13 @@ public class TimeStringCal {
     }
 
     public static void coroutine(final String startTime, final String endTime,
-                                 final TimeFieldType type, final long interval, final Action1<TimeStringCal> action) {
+                                 final TimeFieldType type, final long interval, final Consumer<TimeStringCal> action) {
+        coroutine(startTime, endTime, type, interval, action, 0L);
+    }
+
+    public static void coroutine(final String startTime, final String endTime,
+                                 final TimeFieldType type, final long interval,
+                                 final Consumer<TimeStringCal> action, final long pauseMillis) {
 
         TimeStringCal start = new TimeStringCal(startTime);
         TimeStringCal end = new TimeStringCal(endTime);
@@ -100,9 +106,11 @@ public class TimeStringCal {
 
         while (0L != end.compareTime(start, type.getChronoUnit())) {
             try {
-                action.invoke(start);
+                action.accept(start);
                 start = start.calculateTime(type, intervalCnt);
-                Thread.sleep(1);
+                if (pauseMillis > 0) {
+                    Thread.sleep(pauseMillis);
+                }
 
             } catch (Exception e) {
                 throw new RuntimeException(e);

--- a/src/test/java/org/example/time/timecal/TimeStringCalTest.java
+++ b/src/test/java/org/example/time/timecal/TimeStringCalTest.java
@@ -8,6 +8,7 @@ import static org.junit.jupiter.params.provider.Arguments.arguments;
 
 import java.time.Duration;
 import java.time.temporal.ChronoUnit;
+import java.util.function.Consumer;
 import java.util.stream.Stream;
 import org.assertj.core.api.Assertions;
 import org.example.base.Base;
@@ -158,12 +159,14 @@ class TimeStringCalTest {
     @ParameterizedTest(name = "type: {0}, time1: {1}, time2: {2}, addTime: {3}")
     @MethodSource("addTime2")
     public void CoroutineTest(TimeFieldType type, String time1, String time2, long addTime) {
-        TimeStringCal.coroutine(time1, time2, type, addTime, (start) -> System.out.println("-->" +  start.getTime()));
+        Consumer<TimeStringCal> print = (start) -> System.out.println("-->" +  start.getTime());
+        TimeStringCal.coroutine(time1, time2, type, addTime, print);
     }
 
     @Test
     public void CoroutineTest2() {
-        TimeStringCal.coroutine("20230405000004", "20230405000004000000100", NANO_SECOND, 1L, (start) -> System.out.println("-->" +  start.getTime()));
+        Consumer<TimeStringCal> print = (start) -> System.out.println("-->" +  start.getTime());
+        TimeStringCal.coroutine("20230405000004", "20230405000004000000100", NANO_SECOND, 1L, print);
     }
 
     static Stream<Arguments> addTime2() {


### PR DESCRIPTION
## Summary
- accept `Consumer<TimeStringCal>` in `TimeStringCal.coroutine`
- allow optional pause between iterations and remove fixed `Thread.sleep`
- update tests to call `coroutine` with `Consumer`

## Testing
- `./gradlew test` *(fails: No route to host)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for specifying a pause duration between coroutine steps.

- **Refactor**
  - Improved compatibility by updating coroutine methods to use standard Java interfaces.
  - Enhanced test clarity by extracting print actions into named variables.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->