### PR TITLE
Add TimeUtils with zone-based utilities

### DIFF
--- a/src/main/java/org/example/time/TimeUtils.java
+++ b/src/main/java/org/example/time/TimeUtils.java
@@ -1,0 +1,33 @@
+package org.example.time;
+
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+import org.example.time.timeformat.ITimeForm;
+
+public class TimeUtils {
+
+    private TimeUtils() {
+        throw new UnsupportedOperationException();
+    }
+
+    public static String now(ITimeForm format, ZoneId zone) {
+        ZonedDateTime zonedDateTime = ZonedDateTime.now(zone);
+        LocalDateTime localDateTime = zonedDateTime.toLocalDateTime();
+        return localDateTime.format(DateTimeFormatter.ofPattern(format.getForm()));
+    }
+
+    public static long toEpochMillis(String time, ITimeForm format, ZoneId zone) {
+        LocalDateTime localDateTime = format.convertTimeFormatLocal(time, format);
+        ZonedDateTime zonedDateTime = localDateTime.atZone(zone);
+        return zonedDateTime.toInstant().toEpochMilli();
+    }
+
+    public static String fromEpochMillis(long epochMillis, ITimeForm format, ZoneId zone) {
+        ZonedDateTime zonedDateTime = ZonedDateTime.ofInstant(Instant.ofEpochMilli(epochMillis), zone);
+        LocalDateTime localDateTime = zonedDateTime.toLocalDateTime();
+        return localDateTime.format(DateTimeFormatter.ofPattern(format.getForm()));
+    }
+}

--- a/src/test/java/org/example/time/TimeUtilsTest.java
+++ b/src/test/java/org/example/time/TimeUtilsTest.java
@@ -1,0 +1,40 @@
+package org.example.time;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.ZoneId;
+import org.example.time.timeformat.TimeFormStd;
+import org.example.time.timezone.TimeZoneType;
+import org.junit.jupiter.api.Test;
+
+class TimeUtilsTest {
+
+    @Test
+    void nowReturnsFormattedTime() {
+        ZoneId zone = ZoneId.of(TimeZoneType.SEOUL.getTimeZoneStr());
+        String now = TimeUtils.now(TimeFormStd.YYYYMMDDHH24MISS, zone);
+        assertThat(now.length()).isEqualTo(TimeFormStd.YYYYMMDDHH24MISS.getLen());
+    }
+
+    @Test
+    void epochRoundTrip() {
+        String time = "20240101010101";
+        ZoneId zone = ZoneId.of(TimeZoneType.SEOUL.getTimeZoneStr());
+        long epoch = TimeUtils.toEpochMillis(time, TimeFormStd.YYYYMMDDHH24MISS, zone);
+        String back = TimeUtils.fromEpochMillis(epoch, TimeFormStd.YYYYMMDDHH24MISS, zone);
+        assertThat(back).isEqualTo(time);
+    }
+
+    @Test
+    void convertBetweenZones() {
+        String seoulTime = "20240101080000";
+        ZoneId seoul = ZoneId.of(TimeZoneType.SEOUL.getTimeZoneStr());
+        long epoch = TimeUtils.toEpochMillis(seoulTime, TimeFormStd.YYYYMMDDHH24MISS, seoul);
+
+        ZoneId london = ZoneId.of(TimeZoneType.LONDON.getTimeZoneStr());
+        String londonTime = TimeUtils.fromEpochMillis(epoch, TimeFormStd.YYYYMMDDHH24MISS, london);
+        long epochAgain = TimeUtils.toEpochMillis(londonTime, TimeFormStd.YYYYMMDDHH24MISS, london);
+        assertThat(epochAgain).isEqualTo(epoch);
+        assertThat(londonTime).isNotEqualTo(seoulTime);
+    }
+}


### PR DESCRIPTION
## Summary
- add `TimeUtils` providing helpers to work with zones
- test conversions and formatting with `TimeFormStd` and `TimeZoneType`

## Testing
- `./gradlew test` *(fails: No route to host)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a utility for time formatting and conversion, including methods to get the current time in a specific format and timezone, convert time strings to epoch milliseconds, and convert epoch milliseconds back to formatted time strings.

- **Tests**
  - Added tests to ensure correct time formatting, epoch conversions, and timezone handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->